### PR TITLE
Improve SEO: metadata, heading hierarchy, OG image & accessibility

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,13 +8,16 @@ import type { PropsWithChildren } from "react";
 
 import "@styles/global.css";
 
+const description =
+  "Ignacio Gurí — Senior Frontend Engineer specializing in React, TypeScript, and Node.js. View my experience, skills, and open-source projects.";
+
 export const metadata: Metadata = {
   metadataBase: new URL("https://ignacioguri.me"),
   title: {
-    default: "Ignacio Gurí's page",
+    default: "Ignacio Gurí — Senior Frontend Engineer",
     template: "%s | Ignacio Gurí",
   },
-  description: "This is Ignacio Gurí's personal webpage",
+  description,
   authors: [{ name: "Ignacio Gurí" }],
   icons: {
     icon: "/favicon.ico",
@@ -22,17 +25,17 @@ export const metadata: Metadata = {
   },
   manifest: "/site.webmanifest",
   openGraph: {
-    title: "Ignacio Gurí's page",
-    description: "This is Ignacio Gurí's personal webpage",
+    title: "Ignacio Gurí — Senior Frontend Engineer",
+    description,
     url: "https://ignacioguri.me",
     siteName: "Ignacio Gurí",
     type: "website",
     locale: "en_US",
   },
   twitter: {
-    card: "summary",
-    title: "Ignacio Gurí's page",
-    description: "This is Ignacio Gurí's personal webpage",
+    card: "summary_large_image",
+    title: "Ignacio Gurí — Senior Frontend Engineer",
+    description,
   },
 };
 
@@ -69,6 +72,21 @@ export default function RootLayout({ children }: PropsWithChildren) {
               name: "Ignacio Gurí",
               url: "https://ignacioguri.me",
               jobTitle: "Senior Frontend Engineer",
+              description:
+                "Senior Frontend Engineer specializing in React, TypeScript, and Node.js.",
+              knowsAbout: [
+                "React",
+                "TypeScript",
+                "JavaScript",
+                "Node.js",
+                "Next.js",
+                "Vue.js",
+                "HTML",
+                "CSS",
+                "Swift",
+                "Firebase",
+                "AWS",
+              ],
               sameAs: ["https://www.linkedin.com/in/ignacio-guri/", "https://github.com/ignaguri"],
             }),
           }}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,75 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "Ignacio Gurí — Senior Frontend Engineer";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #1e293b 0%, #0f172a 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            color: "#f8fafc",
+            letterSpacing: "-0.02em",
+            marginBottom: 16,
+          }}
+        >
+          Ignacio Gurí
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            color: "#94a3b8",
+            fontWeight: 400,
+          }}
+        >
+          Senior Frontend Engineer
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            marginTop: 40,
+            fontSize: 20,
+            color: "#64748b",
+          }}
+        >
+          <span>React</span>
+          <span>·</span>
+          <span>TypeScript</span>
+          <span>·</span>
+          <span>Node.js</span>
+          <span>·</span>
+          <span>Next.js</span>
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            bottom: 40,
+            fontSize: 18,
+            color: "#475569",
+          }}
+        >
+          ignacioguri.me
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -8,68 +8,66 @@ export const contentType = "image/png";
 
 export default function OGImage() {
   return new ImageResponse(
-    (
+    <div
+      style={{
+        background: "linear-gradient(135deg, #1e293b 0%, #0f172a 100%)",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
       <div
         style={{
-          background: "linear-gradient(135deg, #1e293b 0%, #0f172a 100%)",
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          fontFamily: "system-ui, sans-serif",
+          fontSize: 72,
+          fontWeight: 700,
+          color: "#f8fafc",
+          letterSpacing: "-0.02em",
+          marginBottom: 16,
         }}
       >
-        <div
-          style={{
-            fontSize: 72,
-            fontWeight: 700,
-            color: "#f8fafc",
-            letterSpacing: "-0.02em",
-            marginBottom: 16,
-          }}
-        >
-          Ignacio Gurí
-        </div>
-        <div
-          style={{
-            fontSize: 32,
-            color: "#94a3b8",
-            fontWeight: 400,
-          }}
-        >
-          Senior Frontend Engineer
-        </div>
-        <div
-          style={{
-            display: "flex",
-            gap: 16,
-            marginTop: 40,
-            fontSize: 20,
-            color: "#64748b",
-          }}
-        >
-          <span>React</span>
-          <span>·</span>
-          <span>TypeScript</span>
-          <span>·</span>
-          <span>Node.js</span>
-          <span>·</span>
-          <span>Next.js</span>
-        </div>
-        <div
-          style={{
-            position: "absolute",
-            bottom: 40,
-            fontSize: 18,
-            color: "#475569",
-          }}
-        >
-          ignacioguri.me
-        </div>
+        Ignacio Gurí
       </div>
-    ),
+      <div
+        style={{
+          fontSize: 32,
+          color: "#94a3b8",
+          fontWeight: 400,
+        }}
+      >
+        Senior Frontend Engineer
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: 16,
+          marginTop: 40,
+          fontSize: 20,
+          color: "#64748b",
+        }}
+      >
+        <span>React</span>
+        <span>·</span>
+        <span>TypeScript</span>
+        <span>·</span>
+        <span>Node.js</span>
+        <span>·</span>
+        <span>Next.js</span>
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 40,
+          fontSize: 18,
+          color: "#475569",
+        }}
+      >
+        ignacioguri.me
+      </div>
+    </div>,
     { ...size },
   );
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: "/secret",
+      disallow: ["/secret", "/api/"],
     },
     sitemap: "https://ignacioguri.me/sitemap.xml",
   };

--- a/app/secret/page.tsx
+++ b/app/secret/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Client info page",
+  robots: "noindex, nofollow",
 };
 
 async function getClientInfo() {

--- a/components/Accordion/index.tsx
+++ b/components/Accordion/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import classNames from "classnames";
-import { createElement, useState } from "react";
+import { createElement, useId, useState } from "react";
 
 import type { PropsWithChildren } from "react";
 
@@ -24,9 +24,22 @@ export default function Accordion({
   children,
 }: Props) {
   const [isOpen, setIsOpen] = useState(initOpen);
+  const id = useId();
+  const contentId = `accordion-content-${id}`;
 
-  const headerContent = (
-    <>
+  const toggleButton = (
+    <button
+      type="button"
+      className={classNames(
+        "flex w-full justify-between items-center focus:outline-none p-4 text-xl font-semibold cursor-pointer transition-all duration-200 ease-in-out",
+        headerClassName,
+        "bg-linear-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 text-gray-900 dark:text-gray-100 hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-700 dark:hover:to-gray-600",
+        "border-b border-gray-200 dark:border-gray-600",
+      )}
+      onClick={() => setIsOpen(!isOpen)}
+      aria-expanded={isOpen}
+      aria-controls={contentId}
+    >
       <span className="flex-1">{header}</span>
       <span className="ml-4 transition-transform duration-300 ease-in-out">
         <ChevronIcon
@@ -36,48 +49,16 @@ export default function Accordion({
           })}
         />
       </span>
-    </>
+    </button>
   );
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
-      {headingLevel &&
-        createElement(
-          headingLevel,
-          { className: "m-0" },
-          <button
-            type="button"
-            className={classNames(
-              "flex w-full justify-between items-center focus:outline-none p-4 text-xl font-semibold cursor-pointer transition-all duration-200 ease-in-out",
-              headerClassName,
-              "bg-linear-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 text-gray-900 dark:text-gray-100 hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-700 dark:hover:to-gray-600",
-              "border-b border-gray-200 dark:border-gray-600",
-            )}
-            onClick={() => setIsOpen(!isOpen)}
-            aria-expanded={isOpen}
-            aria-controls={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
-          >
-            {headerContent}
-          </button>,
-        )}
-      {!headingLevel && (
-        <button
-          type="button"
-          className={classNames(
-            "flex w-full justify-between items-center focus:outline-none p-4 text-xl font-semibold cursor-pointer transition-all duration-200 ease-in-out",
-            headerClassName,
-            "bg-linear-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 text-gray-900 dark:text-gray-100 hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-700 dark:hover:to-gray-600",
-            "border-b border-gray-200 dark:border-gray-600",
-          )}
-          onClick={() => setIsOpen(!isOpen)}
-          aria-expanded={isOpen}
-          aria-controls={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
-        >
-          {headerContent}
-        </button>
-      )}
+      {headingLevel
+        ? createElement(headingLevel, { className: "m-0" }, toggleButton)
+        : toggleButton}
       <div
-        id={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
+        id={contentId}
         className={classNames(
           "transition-all duration-300 ease-in-out",
           {

--- a/components/Accordion/index.tsx
+++ b/components/Accordion/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import classNames from "classnames";
-import { useState } from "react";
+import { createElement, useState } from "react";
 
 import type { PropsWithChildren } from "react";
 
@@ -10,46 +10,72 @@ import ChevronIcon from "../Icons/Chevron";
 interface Props extends PropsWithChildren {
   initOpen: boolean;
   header: string;
+  headingLevel?: "h2" | "h3" | "h4";
   headerClassName?: string;
   bodyClassName?: string;
-  tabIndex?: number;
 }
 
 export default function Accordion({
   initOpen = false,
   header,
+  headingLevel,
   headerClassName,
   bodyClassName,
-  tabIndex = 0,
   children,
 }: Props) {
   const [isOpen, setIsOpen] = useState(initOpen);
 
+  const headerContent = (
+    <>
+      <span className="flex-1">{header}</span>
+      <span className="ml-4 transition-transform duration-300 ease-in-out">
+        <ChevronIcon
+          className={classNames("transition-all duration-300 ease-in-out w-5 h-5", {
+            "rotate-90": isOpen,
+            "rotate-0": !isOpen,
+          })}
+        />
+      </span>
+    </>
+  );
+
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
-      <div
-        role="button"
-        className={classNames(
-          "flex justify-between items-center focus:outline-none p-4 text-xl font-semibold cursor-pointer transition-all duration-200 ease-in-out",
-          headerClassName,
-          "bg-linear-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 text-gray-900 dark:text-gray-100 hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-700 dark:hover:to-gray-600",
-          "border-b border-gray-200 dark:border-gray-600",
+      {headingLevel &&
+        createElement(
+          headingLevel,
+          { className: "m-0" },
+          <button
+            type="button"
+            className={classNames(
+              "flex w-full justify-between items-center focus:outline-none p-4 text-xl font-semibold cursor-pointer transition-all duration-200 ease-in-out",
+              headerClassName,
+              "bg-linear-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 text-gray-900 dark:text-gray-100 hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-700 dark:hover:to-gray-600",
+              "border-b border-gray-200 dark:border-gray-600",
+            )}
+            onClick={() => setIsOpen(!isOpen)}
+            aria-expanded={isOpen}
+            aria-controls={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
+          >
+            {headerContent}
+          </button>,
         )}
-        onClick={() => setIsOpen(!isOpen)}
-        tabIndex={tabIndex}
-        aria-expanded={isOpen}
-        aria-controls={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
-      >
-        <span className="flex-1">{header}</span>
-        <span className="ml-4 transition-transform duration-300 ease-in-out">
-          <ChevronIcon
-            className={classNames("transition-all duration-300 ease-in-out w-5 h-5", {
-              "rotate-0": isOpen,
-              "rotate-180": !isOpen,
-            })}
-          />
-        </span>
-      </div>
+      {!headingLevel && (
+        <button
+          type="button"
+          className={classNames(
+            "flex w-full justify-between items-center focus:outline-none p-4 text-xl font-semibold cursor-pointer transition-all duration-200 ease-in-out",
+            headerClassName,
+            "bg-linear-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 text-gray-900 dark:text-gray-100 hover:from-gray-100 hover:to-gray-50 dark:hover:from-gray-700 dark:hover:to-gray-600",
+            "border-b border-gray-200 dark:border-gray-600",
+          )}
+          onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
+        >
+          {headerContent}
+        </button>
+      )}
       <div
         id={`accordion-content-${header.replace(/\s+/g, "-").toLowerCase()}`}
         className={classNames(

--- a/sections/Abstract/index.tsx
+++ b/sections/Abstract/index.tsx
@@ -3,8 +3,8 @@ import Accordion from "@components/Accordion";
 export default function Abstract() {
   return (
     <section className="max-w-sm mt-5 md:max-w-lg lg:max-w-4xl">
-      <Accordion header="About me" initOpen>
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 text-left italic mx-1 mt-1 mb-2">
+      <Accordion header="About me" headingLevel="h2" initOpen>
+        <p className="text-sm text-gray-600 dark:text-gray-300 text-left italic mx-1 mt-1 mb-2">
           Currently working as Senior Frontend Engineer @{" "}
           <a
             className="no-underline text-blue-600 dark:text-blue-400"
@@ -13,7 +13,7 @@ export default function Abstract() {
           >
             Holidu GmbH
           </a>
-        </h2>
+        </p>
         <p className="text-base text-gray-700 dark:text-gray-300 text-left m-1">
           I am a Software Engineer capable of analyzing, designing, developing, testing, and
           debugging high scalability and high performance Web/Web-mobile & iOS applications.

--- a/sections/Experience/index.tsx
+++ b/sections/Experience/index.tsx
@@ -77,7 +77,7 @@ export default function Experience() {
 
   return (
     <section className="max-w-sm mt-4 md:max-w-lg lg:max-w-4xl">
-      <Accordion header="Experience" initOpen>
+      <Accordion header="Experience" headingLevel="h2" initOpen>
         <div className="mt-6 space-y-8">
           {experiences.map((exp, index) => (
             <div key={exp.id} className="relative">

--- a/sections/Projects/Skeleton.tsx
+++ b/sections/Projects/Skeleton.tsx
@@ -23,10 +23,10 @@ const CardSkeleton = () => (
 export default function ProjectsSkeleton() {
   return (
     <section className="max-w-sm mt-5 md:max-w-lg lg:max-w-4xl">
-      <Accordion header="Projects" initOpen>
-        <h3 className="text-base text-gray-500 dark:text-gray-400 text-left m-1">
+      <Accordion header="Projects" headingLevel="h2" initOpen>
+        <p className="text-base text-gray-500 dark:text-gray-400 text-left m-1">
           Some side projects I&apos;ve done
-        </h3>
+        </p>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 mb-4">
           {Array.from({ length: 6 }).map((_, i) => (
             <CardSkeleton key={i} />

--- a/sections/Projects/index.tsx
+++ b/sections/Projects/index.tsx
@@ -7,9 +7,9 @@ const Card = ({ name, description, techs, repo, link }: Project) => {
   return (
     <div className="max-w-sm p-4 bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-solid border-gray-200 dark:border-gray-700 flex flex-col justify-between">
       <div>
-        <h2 className="text-gray-800 dark:text-gray-100 font-medium text-base sm:text-lg">
+        <h3 className="text-gray-800 dark:text-gray-100 font-medium text-base sm:text-lg">
           {name}
-        </h2>
+        </h3>
         <p className="mt-2 text-sm lg:text-base text-gray-600 dark:text-gray-300 italic">
           {description}
         </p>
@@ -64,10 +64,10 @@ export default async function Projects() {
 
   return (
     <section className="max-w-sm mt-5 md:max-w-lg lg:max-w-4xl">
-      <Accordion header="Projects" initOpen>
-        <h3 className="text-base text-gray-500 dark:text-gray-400 text-left m-1">
+      <Accordion header="Projects" headingLevel="h2" initOpen>
+        <p className="text-base text-gray-500 dark:text-gray-400 text-left m-1">
           Some side projects I&apos;ve done
-        </h3>
+        </p>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 mb-4">
           {projects.map((project: Project) => (
             <Card key={project.name} {...project} />

--- a/sections/Skills/index.tsx
+++ b/sections/Skills/index.tsx
@@ -9,7 +9,7 @@ import logos from "./logos";
 export default function Skills() {
   return (
     <section className="max-w-sm mt-5 md:max-w-lg lg:max-w-4xl">
-      <Accordion header="Skills" initOpen>
+      <Accordion header="Skills" headingLevel="h2" initOpen>
         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6">
           {logos.map((logo: Logo) => (
             <div

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "noEmit": true,
     "incremental": true,
@@ -20,21 +16,11 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@components/*": [
-        "components/*"
-      ],
-      "@lib/*": [
-        "lib/*"
-      ],
-      "@pages/*": [
-        "pages/*"
-      ],
-      "@sections/*": [
-        "sections/*"
-      ],
-      "@styles/*": [
-        "styles/*"
-      ]
+      "@components/*": ["components/*"],
+      "@lib/*": ["lib/*"],
+      "@pages/*": ["pages/*"],
+      "@sections/*": ["sections/*"],
+      "@styles/*": ["styles/*"]
     },
     "plugins": [
       {
@@ -49,7 +35,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Keyword-rich title and meta description with job title and tech stack
- Accordion now supports a `headingLevel` prop for semantic `<h2>`/`<h3>` headings, fixing the heading hierarchy (h1 > h2 > h3)
- Replaced `div[role="button"]` with semantic `<button>` in Accordion for better accessibility
- Added dynamic Open Graph image (`opengraph-image.tsx`) for social sharing previews
- Enriched JSON-LD Person schema with `knowsAbout` and `description`
- Added `noindex, nofollow` to `/secret` page metadata
- Blocked `/api/` in robots.txt
- Fixed chevron direction: right (collapsed) → down (expanded)
- Fixed misused heading tags in Abstract (`<h2>` → `<p>`), Projects (`<h3>` → `<p>`), and Project cards (`<h2>` → `<h3>`)
